### PR TITLE
Bugfix/spotify parser

### DIFF
--- a/src/Parsers/Spotify.php
+++ b/src/Parsers/Spotify.php
@@ -6,8 +6,7 @@ class Spotify
 {
     public static function parse(string $content): string
     {
-        return preg_replace_callback('/\[spotify uri="(.+)"]/', function ($matches)
-        {
+        return preg_replace_callback('/\[spotify uri="(.+)"]/', function ($matches) {
             $url = $matches[1] ?? null;
             $url = str_contains($url, 'album:') ? $url : null;
             $url = $url ? str_replace(
@@ -16,8 +15,7 @@ class Spotify
                 $url
             ) : null;
 
-            if ($url)
-            {
+            if ($url) {
                 return view('shortcode-plus::spotify', ['url' => $url]);
             }
 

--- a/src/Parsers/Spotify.php
+++ b/src/Parsers/Spotify.php
@@ -6,16 +6,18 @@ class Spotify
 {
     public static function parse(string $content): string
     {
-        return preg_replace_callback('/\[spotify uri="(.+)"]/', function ($matches) {
+        return preg_replace_callback('/\[spotify uri="(.+)"]/', function ($matches)
+        {
             $url = $matches[1] ?? null;
-            $url = str_contains($url, 'spotify') ? $url : null;
+            $url = str_contains($url, 'album:') ? $url : null;
             $url = $url ? str_replace(
-                'spotify:album:',
+                'album:',
                 'https://open.spotify.com/embed/album/',
                 $url
             ) : null;
 
-            if ($url) {
+            if ($url)
+            {
                 return view('shortcode-plus::spotify', ['url' => $url]);
             }
 


### PR DESCRIPTION
The matched URL contains only `album:xxxxxxxxx` and not the string "spotify"; without this change the parse method returns "No spotify URI defined" even with a valid URL.